### PR TITLE
Remove SITE_TITLE from page title

### DIFF
--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="keywords" content="{% block meta_keywords %}{% endblock %}">
 <meta name="description" content="{% block meta_description %}{% endblock %}">
-<title>{% block meta_title %}{% endblock %}{% if settings.SITE_TITLE %} | {{ settings.SITE_TITLE }}{% endif %}</title>
+<title>{% block meta_title %}{% endblock %}</title>
 <link rel="shortcut icon" href="{% static "img/favicon.ico" %}">
 {% ifinstalled mezzanine.blog %}
 <link rel="alternate" type="application/rss+xml" title="RSS" href="{% url "blog_post_feed" "rss" %}">


### PR DESCRIPTION
Removes the undesirable `| SITE_TITLE` from every page title
