### PR TITLE
Handle data without explicit units

### DIFF
--- a/energize_andover/script/parse.py
+++ b/energize_andover/script/parse.py
@@ -15,14 +15,13 @@ def parse(input_file):
         pandas DataFrame, with timestamps as index and measurement variables as columns
     """
     # Read the file into a pandas Series with MultiIndex
-    df = pd.read_csv(input_file, index_col=[0, 1])['Object Value']
+    df = pd.read_csv(input_file,
+                     index_col=[0, 1],
+                     converters={'Object Value': drop_units})['Object Value']
 
     # Drop duplicate measurements
     df = df.groupby(df.index).last()
     df.index = pd.MultiIndex.from_tuples(df.index)
-
-    # Remove units from values, so that they are numeric
-    df = df.apply(drop_units)
 
     # Transform df from 1-dimensional Series with MultiIndex to 2-dimensional DataFrame
     df = df.unstack(level=-1)

--- a/energize_andover/script/parse.py
+++ b/energize_andover/script/parse.py
@@ -48,7 +48,7 @@ def drop_prefix(variable_name):
 
 def drop_units(value):
     """Remove the units from a string, e.g. '309.2 kWh' -> 309.2"""
-    pattern = re.compile(r"\A(\d*\.?\d+) [a-zA-Z]+\Z")
+    pattern = re.compile(r"\A(\d*\.?\d+) ?[a-zA-Z]*\Z")
     match = pattern.match(value)
     if match is None:
         # value was not of the expected format


### PR DESCRIPTION
Sometimes the input file does not list the units next to each value.  The change here will make the `parse` function read the values correctly in that case.
